### PR TITLE
Revert Telegram optional configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You should see the following output:
   - On top of this fee, minimal solana network fee will be applied
 - `MAX_LAG` - Ignore tokens that PoolOpenTime is longer than now + `MAX_LAG` seconds
 - `USE_TA` - Use technical analysis for entries and exits (VERY HARD ON RPC's)
-- `USE_TELEGRAM` - Use telegram bot for notifications (automatically disabled if `TELEGRAM_BOT_TOKEN` or `TELEGRAM_CHAT_ID` are empty)
+- `USE_TELEGRAM` - Use telegram bot for notifications
 
 #### Buy
 

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -14,8 +14,6 @@ const retrieveEnvVariable = (variableName: string, logger: Logger) => {
   return variable;
 };
 
-const retrieveOptionalEnvVariable = (variableName: string) => process.env[variableName] || '';
-
 // Wallet
 export const PRIVATE_KEY = retrieveEnvVariable('PRIVATE_KEY', logger);
 
@@ -36,8 +34,7 @@ export const TRANSACTION_EXECUTOR = retrieveEnvVariable('TRANSACTION_EXECUTOR', 
 export const CUSTOM_FEE = retrieveEnvVariable('CUSTOM_FEE', logger);
 export const MAX_LAG = Number(retrieveEnvVariable('MAX_LAG', logger));
 export const USE_TA = retrieveEnvVariable('USE_TA', logger) === 'true';
-const USE_TELEGRAM_ENV = retrieveEnvVariable('USE_TELEGRAM', logger);
-let useTelegram = USE_TELEGRAM_ENV === 'true';
+export const USE_TELEGRAM = retrieveEnvVariable('USE_TELEGRAM', logger) === 'true';
 
 // Buy
 export const AUTO_BUY_DELAY = Number(retrieveEnvVariable('AUTO_BUY_DELAY', logger));
@@ -93,31 +90,8 @@ export const TOP_10_MAX_PERCENTAGE = Number (retrieveEnvVariable('TOP_10_MAX_PER
 export const HOLDER_MIN_AMOUNT = Number (retrieveEnvVariable('HOLDER_MIN_AMOUNT', logger));
 
 //Telegram config
-const TELEGRAM_BOT_TOKEN_ENV = retrieveOptionalEnvVariable('TELEGRAM_BOT_TOKEN');
-const TELEGRAM_CHAT_ID_ENV = retrieveOptionalEnvVariable('TELEGRAM_CHAT_ID');
-
-if (useTelegram) {
-  if (!TELEGRAM_BOT_TOKEN_ENV) {
-    logger.warn('TELEGRAM_BOT_TOKEN is not set. Disabling Telegram notifications.');
-    useTelegram = false;
-  }
-
-  if (!TELEGRAM_CHAT_ID_ENV) {
-    logger.warn('TELEGRAM_CHAT_ID is not set. Disabling Telegram notifications.');
-    useTelegram = false;
-  }
-}
-
-const TELEGRAM_CHAT_ID_NUMBER = TELEGRAM_CHAT_ID_ENV ? Number(TELEGRAM_CHAT_ID_ENV) : 0;
-
-if (useTelegram && TELEGRAM_CHAT_ID_ENV && Number.isNaN(TELEGRAM_CHAT_ID_NUMBER)) {
-  logger.error('TELEGRAM_CHAT_ID must be a number');
-  process.exit(1);
-}
-
-export const TELEGRAM_BOT_TOKEN = TELEGRAM_BOT_TOKEN_ENV;
-export const TELEGRAM_CHAT_ID = TELEGRAM_CHAT_ID_NUMBER;
-export const USE_TELEGRAM = useTelegram;
+export const TELEGRAM_BOT_TOKEN = retrieveEnvVariable('TELEGRAM_BOT_TOKEN', logger);
+export const TELEGRAM_CHAT_ID = Number (retrieveEnvVariable('TELEGRAM_CHAT_ID', logger));
 
 //Technical analysis
 export const MACD_SHORT_PERIOD = Number (retrieveEnvVariable('MACD_SHORT_PERIOD', logger));

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,13 @@
         "pino": "^8.18.0",
         "pino-pretty": "^10.3.1",
         "pino-std-serializers": "^6.2.2",
-        "telegraf": "^4.16.3",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
+        "telegraf": "^4.16.3"
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.5",
-        "prettier": "^3.2.4"
+        "prettier": "^3.2.4",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -42,6 +42,7 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -52,6 +53,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -59,10 +61,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -353,18 +357,22 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/bn.js": {
@@ -405,6 +413,7 @@
     },
     "node_modules/acorn": {
       "version": "8.8.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -415,6 +424,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -432,6 +442,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-mutex": {
@@ -627,6 +638,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dateformat": {
@@ -684,6 +696,7 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -902,6 +915,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/mime-db": {
@@ -3855,6 +3869,7 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -3900,6 +3915,7 @@
     },
     "node_modules/typescript": {
       "version": "5.3.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3930,6 +3946,7 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
@@ -3969,6 +3986,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "pino": "^8.18.0",
     "pino-pretty": "^10.3.1",
     "pino-std-serializers": "^6.2.2",
-    "telegraf": "^4.16.3",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "telegraf": "^4.16.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.5",
-    "prettier": "^3.2.4"
+    "prettier": "^3.2.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- revert the logic that disabled trades when Telegram credentials were missing by requiring the configuration again
- restore the README documentation describing Telegram usage without the automatic disable note
- move ts-node and typescript back to devDependencies to match the original dependency layout while keeping the current .env.copy settings

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d6afac17d8832abb2c4b8937e13d36