### PR TITLE
Allow optional Telegram and TA configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ You should see the following output:
   - On top of this fee, minimal solana network fee will be applied
 - `MAX_LAG` - Ignore tokens that PoolOpenTime is longer than now + `MAX_LAG` seconds
 - `USE_TA` - Use technical analysis for entries and exits (VERY HARD ON RPC's)
+  - Set to `false` to disable technical analysis indicators; the MACD/RSI environment variables are not required in that case.
 - `USE_TELEGRAM` - Use telegram bot for notifications
+  - Set to `false` to disable Telegram integration; `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` can be omitted when disabled.
 
 #### Buy
 
@@ -134,6 +136,19 @@ Note: When using snipe list filters below will be disabled.
 - `MACD_SIGNAL_PERIOD` - default 9
 
 - `RSI_PERIOD` - default 14
+
+> ℹ️ These indicators are only required when `USE_TA=true`. When technical analysis is disabled you can leave them unset and the bot will still start successfully.
+
+### Starting without Telegram or technical analysis
+
+Set the following feature flags to `false` in your environment to skip their related credentials:
+
+```
+USE_TELEGRAM=false
+USE_TA=false
+```
+
+With this configuration you can omit `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `MACD_SHORT_PERIOD`, `MACD_LONG_PERIOD`, `MACD_SIGNAL_PERIOD`, and `RSI_PERIOD` from your `.env`. The bot will log that Telegram and technical analysis are disabled and will start normally.
 
 ## Warp transactions (beta)
 

--- a/bot.ts
+++ b/bot.ts
@@ -58,20 +58,20 @@ export interface BotConfig {
   checkHolders: boolean;
   checkTokenDistribution: boolean;
   checkAbnormalDistribution: boolean;
-  telegramChatId: number;
-  telegramBotToken: string,
-  blacklistRefreshInterval: number,
-  MACDLongPeriod: number,
-  MACDShortPeriod: number,
-  MACDSignalPeriod: number,
-  RSIPeriod: number,
-  autoSellWithoutSellSignal: boolean,
-  buySignalTimeToWait: number,
-  buySignalPriceInterval: number,
-  buySignalFractionPercentageTimeToWait: number,
-  buySignalLowVolumeThreshold: number,
-  useTechnicalAnalysis: boolean,
-  useTelegram: boolean
+  telegramChatId?: number;
+  telegramBotToken?: string;
+  blacklistRefreshInterval: number;
+  MACDLongPeriod?: number;
+  MACDShortPeriod?: number;
+  MACDSignalPeriod?: number;
+  RSIPeriod?: number;
+  autoSellWithoutSellSignal: boolean;
+  buySignalTimeToWait: number;
+  buySignalPriceInterval: number;
+  buySignalFractionPercentageTimeToWait: number;
+  buySignalLowVolumeThreshold: number;
+  useTechnicalAnalysis: boolean;
+  useTelegram: boolean;
 }
 
 export class Bot {

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -33,8 +33,8 @@ export const CACHE_NEW_MARKETS = retrieveEnvVariable('CACHE_NEW_MARKETS', logger
 export const TRANSACTION_EXECUTOR = retrieveEnvVariable('TRANSACTION_EXECUTOR', logger);
 export const CUSTOM_FEE = retrieveEnvVariable('CUSTOM_FEE', logger);
 export const MAX_LAG = Number(retrieveEnvVariable('MAX_LAG', logger));
-export const USE_TA = retrieveEnvVariable('USE_TA', logger) === 'true';
 export const USE_TELEGRAM = retrieveEnvVariable('USE_TELEGRAM', logger) === 'true';
+export const USE_TA = retrieveEnvVariable('USE_TA', logger) === 'true';
 
 // Buy
 export const AUTO_BUY_DELAY = Number(retrieveEnvVariable('AUTO_BUY_DELAY', logger));
@@ -90,12 +90,24 @@ export const TOP_10_MAX_PERCENTAGE = Number (retrieveEnvVariable('TOP_10_MAX_PER
 export const HOLDER_MIN_AMOUNT = Number (retrieveEnvVariable('HOLDER_MIN_AMOUNT', logger));
 
 //Telegram config
-export const TELEGRAM_BOT_TOKEN = retrieveEnvVariable('TELEGRAM_BOT_TOKEN', logger);
-export const TELEGRAM_CHAT_ID = Number (retrieveEnvVariable('TELEGRAM_CHAT_ID', logger));
+export const TELEGRAM_BOT_TOKEN = USE_TELEGRAM
+  ? retrieveEnvVariable('TELEGRAM_BOT_TOKEN', logger)
+  : undefined;
+export const TELEGRAM_CHAT_ID = USE_TELEGRAM
+  ? Number(retrieveEnvVariable('TELEGRAM_CHAT_ID', logger))
+  : undefined;
 
 //Technical analysis
-export const MACD_SHORT_PERIOD = Number (retrieveEnvVariable('MACD_SHORT_PERIOD', logger));
-export const MACD_LONG_PERIOD = Number (retrieveEnvVariable('MACD_LONG_PERIOD', logger));
-export const MACD_SIGNAL_PERIOD = Number (retrieveEnvVariable('MACD_SIGNAL_PERIOD', logger));
+export const MACD_SHORT_PERIOD = USE_TA
+  ? Number(retrieveEnvVariable('MACD_SHORT_PERIOD', logger))
+  : undefined;
+export const MACD_LONG_PERIOD = USE_TA
+  ? Number(retrieveEnvVariable('MACD_LONG_PERIOD', logger))
+  : undefined;
+export const MACD_SIGNAL_PERIOD = USE_TA
+  ? Number(retrieveEnvVariable('MACD_SIGNAL_PERIOD', logger))
+  : undefined;
 
-export const RSI_PERIOD = Number (retrieveEnvVariable('RSI_PERIOD', logger));
+export const RSI_PERIOD = USE_TA
+  ? Number(retrieveEnvVariable('RSI_PERIOD', logger))
+  : undefined;

--- a/index.ts
+++ b/index.ts
@@ -114,6 +114,11 @@ function printDetails(wallet: Keypair, quoteToken: Token, bot: Bot) {
   logger.info(`Cache new markets: ${CACHE_NEW_MARKETS}`);
   logger.info(`Log level: ${LOG_LEVEL}`);
   logger.info(`Max lag: ${MAX_LAG}`);
+  logger.info(`Telegram notifications: ${botConfig.useTelegram}`);
+
+  if (botConfig.useTelegram) {
+    logger.info(`Telegram chat id: ${botConfig.telegramChatId}`);
+  }
 
   logger.info('- Buy -');
   logger.info(`Buy amount: ${botConfig.quoteAmount.toFixed()} ${botConfig.quoteToken.name}`);
@@ -160,8 +165,12 @@ function printDetails(wallet: Keypair, quoteToken: Token, bot: Bot) {
   logger.info(`Check Abnormal Distribution: ${botConfig.checkAbnormalDistribution}`);
   logger.info(`Blacklist refresh interval: ${BLACKLIST_REFRESH_INTERVAL}`);
 
-  logger.info(`Buy signal MACD: ${MACD_SHORT_PERIOD}/${MACD_LONG_PERIOD}/${MACD_SIGNAL_PERIOD}`);
-  logger.info(`Buy signal RSI: ${RSI_PERIOD}`);
+  logger.info(`Technical analysis enabled: ${botConfig.useTechnicalAnalysis}`);
+
+  if (botConfig.useTechnicalAnalysis) {
+    logger.info(`Buy signal MACD: ${botConfig.MACDShortPeriod}/${botConfig.MACDLongPeriod}/${botConfig.MACDSignalPeriod}`);
+    logger.info(`Buy signal RSI: ${botConfig.RSIPeriod}`);
+  }
   
   logger.info('------- CONFIGURATION END -------');
 

--- a/messaging.ts
+++ b/messaging.ts
@@ -3,11 +3,15 @@ import { InlineKeyboardMarkup, Message } from "telegraf/typings/core/types/typeg
 import { BotConfig } from "./bot";
 
 export class Messaging {
-  private readonly tg_bot: Telegraf;
+  private readonly tg_bot?: Telegraf;
 
   constructor(readonly config: BotConfig) {
 
     if (this.config.useTelegram) {
+      if (!this.config.telegramBotToken || !this.config.telegramChatId) {
+        throw new Error('Telegram is enabled but credentials are missing.');
+      }
+
       this.tg_bot = new Telegraf(this.config.telegramBotToken);
       this.setupBot();
       this.tg_bot.launch();
@@ -87,7 +91,7 @@ export class Messaging {
   }
 
   public async sendTelegramMessage(message: string, mint: string, messageId?: number): Promise<Message.TextMessage | undefined> {
-    if(!this.config.useTelegram){
+    if(!this.config.useTelegram || !this.tg_bot){
       return null;
     }
 
@@ -102,13 +106,13 @@ export class Messaging {
       };
 
       if (messageId) {
-        this.tg_bot.telegram.editMessageText(this.config.telegramChatId, messageId, undefined, message, {
+        this.tg_bot.telegram.editMessageText(this.config.telegramChatId!, messageId, undefined, message, {
           parse_mode: "HTML", reply_markup: kb
         });
         return undefined;
 
       } else {
-        return await this.tg_bot.telegram.sendMessage(this.config.telegramChatId, message, {
+        return await this.tg_bot.telegram.sendMessage(this.config.telegramChatId!, message, {
           parse_mode: "HTML", reply_markup: kb
         });
       }

--- a/technicalAnalysis.ts
+++ b/technicalAnalysis.ts
@@ -1,7 +1,18 @@
 import { BotConfig } from "./bot";
 
 export class TechnicalAnalysis {
-    constructor(public botConfig: BotConfig) { }
+    constructor(public botConfig: BotConfig) {
+        if (botConfig.useTechnicalAnalysis) {
+            if (
+                botConfig.MACDShortPeriod == null ||
+                botConfig.MACDLongPeriod == null ||
+                botConfig.MACDSignalPeriod == null ||
+                botConfig.RSIPeriod == null
+            ) {
+                throw new Error('Technical analysis periods must be provided when technical analysis is enabled.');
+            }
+        }
+    }
 
     public calculateEMAs = (prices: number[]): { EMA_3: number, EMA_18: number, prevEMA_3: number } => {
         const shortPeriod = 3;


### PR DESCRIPTION
## Summary
- guard Telegram environment variable retrieval so the bot can start without credentials when USE_TELEGRAM=false
- only require technical analysis indicators when USE_TA=true and add runtime validation for enabled configurations
- document the new optional setup path for running without Telegram or technical analysis

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d6b395bf7c832a9023dd2d47416c0a