### PR TITLE
Introduce pool snapshots for multi-DEX support

### DIFF
--- a/cache/pool.cache.ts
+++ b/cache/pool.cache.ts
@@ -1,29 +1,85 @@
 import { LiquidityStateV4 } from '@raydium-io/raydium-sdk';
+import { PublicKey } from '@solana/web3.js';
 import { logger } from '../helpers';
+import { PumpFunPoolState } from '../helpers/pumpfun/types';
+
+export type PoolType = 'raydium' | 'pumpfun';
+
+export interface BasePoolSnapshot<TState> {
+  id: string;
+  sold: boolean;
+  type: PoolType;
+  baseMint: PublicKey;
+  quoteMint: PublicKey;
+  baseDecimals: number;
+  quoteDecimals: number;
+  state: TState;
+}
+
+export type RaydiumPoolSnapshot = BasePoolSnapshot<LiquidityStateV4> & {
+  type: 'raydium';
+  marketId: PublicKey;
+};
+
+export type PumpFunPoolSnapshot = BasePoolSnapshot<PumpFunPoolState> & {
+  type: 'pumpfun';
+};
+
+export type PoolSnapshot = RaydiumPoolSnapshot | PumpFunPoolSnapshot;
+
+export const isRaydiumPool = (snapshot: PoolSnapshot): snapshot is RaydiumPoolSnapshot =>
+  snapshot.type === 'raydium';
+
+export const isPumpFunPool = (snapshot: PoolSnapshot): snapshot is PumpFunPoolSnapshot =>
+  snapshot.type === 'pumpfun';
+
+export function createRaydiumPoolSnapshot(id: string, state: LiquidityStateV4): RaydiumPoolSnapshot {
+  return {
+    id,
+    sold: false,
+    type: 'raydium',
+    baseMint: state.baseMint,
+    quoteMint: state.quoteMint,
+    baseDecimals: state.baseDecimal.toNumber(),
+    quoteDecimals: state.quoteDecimal.toNumber(),
+    marketId: state.marketId,
+    state,
+  };
+}
+
+export function createPumpFunPoolSnapshot(id: string, state: PumpFunPoolState): PumpFunPoolSnapshot {
+  return {
+    id,
+    sold: false,
+    type: 'pumpfun',
+    baseMint: state.baseMint,
+    quoteMint: state.quoteMint,
+    baseDecimals: state.baseDecimals,
+    quoteDecimals: state.quoteDecimals,
+    state,
+  };
+}
 
 export class PoolCache {
-  private readonly keys: Map<string, { id: string; state: LiquidityStateV4, sold: boolean }> = new Map<
-    string,
-    { id: string; state: LiquidityStateV4, sold: boolean }
-  >();
+  private readonly keys: Map<string, PoolSnapshot> = new Map<string, PoolSnapshot>();
 
-  public save(id: string, state: LiquidityStateV4) {
-    if (!this.keys.has(state.baseMint.toString())) {
-      logger.trace(`Caching new pool for mint: ${state.baseMint.toString()}`);
-      this.keys.set(state.baseMint.toString(), { id, state, sold: false });
+  public save(snapshot: PoolSnapshot) {
+    const mint = snapshot.baseMint.toBase58();
+    if (!this.keys.has(mint)) {
+      logger.trace(`Caching new pool for mint: ${mint}`);
+      this.keys.set(mint, snapshot);
     }
   }
 
-  public async get(mint: string): Promise<{ id: string; state: LiquidityStateV4, sold: boolean }> {
-      return this.keys.get(mint)!;
+  public async get(mint: string): Promise<PoolSnapshot | undefined> {
+    return this.keys.get(mint);
   }
 
   public async markAsSold(mint: string) {
-    //important, so we don't try to sell the same pool twice
+    // important, so we don't try to sell the same pool twice
     const pool = this.keys.get(mint);
     if (pool) {
-      pool.sold = true;
-      this.keys.set(mint, pool);
+      this.keys.set(mint, { ...pool, sold: true });
     }
   }
 }

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -4,4 +4,6 @@ export * from './logger';
 export * from './constants';
 export * from './token';
 export * from './wallet';
-export * from './promises'
+export * from './promises';
+export * from './pumpfun/keys';
+export * from './pumpfun/types';

--- a/helpers/pumpfun/keys.ts
+++ b/helpers/pumpfun/keys.ts
@@ -1,0 +1,34 @@
+import { PublicKey } from '@solana/web3.js';
+import { PumpFunPoolSnapshot } from '../../cache/pool.cache';
+
+export interface PumpFunPoolKeys {
+  id: PublicKey;
+  baseMint: PublicKey;
+  quoteMint: PublicKey;
+  baseVault: PublicKey;
+  quoteVault: PublicKey;
+  bondingCurve: PublicKey;
+  associatedBondingCurve: PublicKey;
+  globalAccount: PublicKey;
+  feeAccount: PublicKey;
+  baseDecimals: number;
+  quoteDecimals: number;
+}
+
+export function createPumpFunPoolKeys(snapshot: PumpFunPoolSnapshot): PumpFunPoolKeys {
+  const { state } = snapshot;
+
+  return {
+    id: new PublicKey(snapshot.id),
+    baseMint: snapshot.baseMint,
+    quoteMint: snapshot.quoteMint,
+    baseVault: state.baseVault,
+    quoteVault: state.quoteVault,
+    bondingCurve: state.bondingCurve,
+    associatedBondingCurve: state.associatedBondingCurve,
+    globalAccount: state.globalAccount,
+    feeAccount: state.feeAccount,
+    baseDecimals: snapshot.baseDecimals,
+    quoteDecimals: snapshot.quoteDecimals,
+  };
+}

--- a/helpers/pumpfun/types.ts
+++ b/helpers/pumpfun/types.ts
@@ -1,0 +1,14 @@
+import { PublicKey } from '@solana/web3.js';
+
+export interface PumpFunPoolState {
+  baseMint: PublicKey;
+  quoteMint: PublicKey;
+  baseVault: PublicKey;
+  quoteVault: PublicKey;
+  baseDecimals: number;
+  quoteDecimals: number;
+  bondingCurve: PublicKey;
+  associatedBondingCurve: PublicKey;
+  globalAccount: PublicKey;
+  feeAccount: PublicKey;
+}

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { MarketCache, PoolCache } from './cache';
+import { MarketCache, PoolCache, createRaydiumPoolSnapshot } from './cache';
 import { Listeners } from './listeners';
 import { Connection, KeyedAccountInfo, Keypair } from '@solana/web3.js';
 import { LIQUIDITY_STATE_LAYOUT_V4, MARKET_STATE_LAYOUT_V3, Token, TokenAmount } from '@raydium-io/raydium-sdk';
@@ -285,14 +285,15 @@ const runListener = async () => {
     let lag = currentTimestamp - poolOpenTime;
 
     if (!exists && poolOpenTime > runTimestamp) {
-      poolCache.save(updatedAccountInfo.accountId.toString(), poolState);
-      
+      const snapshot = createRaydiumPoolSnapshot(updatedAccountInfo.accountId.toString(), poolState);
+      poolCache.save(snapshot);
+
       if(MAX_LAG != 0 && lag > MAX_LAG){
         logger.trace(`Lag too high: ${lag} sec`);
         return;
       } else {
         logger.trace(`Lag: ${lag} sec`);
-        await bot.buy(updatedAccountInfo.accountId, poolState, lag);
+        await bot.buy(snapshot, lag);
       }
     }
   });


### PR DESCRIPTION
## Summary
- add a shared PoolSnapshot abstraction so the cache can track both Raydium and pump.fun pools
- scaffold pump.fun key metadata helpers and re-export them through the helpers barrel file
- update the bot buy/sell logic to consume cached pool snapshots and branch by DEX type before building swap metadata

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d6bd28ac48832aa5f7089e99b070eb