### PR TITLE
Refine bot transaction flow and pool cache structure

### DIFF
--- a/cache/pool.cache.ts
+++ b/cache/pool.cache.ts
@@ -1,40 +1,6 @@
 import { LiquidityStateV4 } from '@raydium-io/raydium-sdk';
 import { PublicKey } from '@solana/web3.js';
 import { logger } from '../helpers';
-import { PumpFunBondingCurveState, PumpFunCachedPoolItem } from '../transactions';
-
-export type CachedPoolItem =
-  | { id: string; type: 'raydium'; state: LiquidityStateV4; sold: boolean }
-  | PumpFunCachedPoolItem;
-
-export class PoolCache {
-  private readonly keys: Map<string, CachedPoolItem> = new Map();
-
-  public save(id: string, state: LiquidityStateV4, type?: 'raydium'): void;
-  public save(id: string, state: PumpFunBondingCurveState, type: 'pumpfun'): void;
-  public save(
-    id: string,
-    state: LiquidityStateV4 | PumpFunBondingCurveState,
-    type: 'raydium' | 'pumpfun' = 'raydium',
-  ) {
-    const mint =
-      type === 'raydium'
-        ? (state as LiquidityStateV4).baseMint.toString()
-        : (state as PumpFunBondingCurveState).mint.toString();
-
-    if (!this.keys.has(mint)) {
-      logger.trace(`Caching new pool for mint: ${mint}`);
-
-      if (type === 'raydium') {
-        this.keys.set(mint, { id, state: state as LiquidityStateV4, sold: false, type });
-      } else {
-        this.keys.set(mint, { id, state: state as PumpFunBondingCurveState, sold: false, type });
-      }
-    }
-  }
-
-  public async get(mint: string): Promise<CachedPoolItem | undefined> {
-
 import { PumpFunPoolState } from '../helpers/pumpfun/types';
 
 export type PoolType = 'raydium' | 'pumpfun';
@@ -110,7 +76,6 @@ export class PoolCache {
   }
 
   public async markAsSold(mint: string) {
-    // important, so we don't try to sell the same pool twice
     const pool = this.keys.get(mint);
     if (pool) {
       this.keys.set(mint, { ...pool, sold: true });


### PR DESCRIPTION
## Summary
- resolve merge conflicts in bot.ts by consolidating configuration handling and buy/sell execution logic
- simplify the pool cache to use unified snapshots for Raydium and pump.fun pools

## Testing
- not run (per instruction)


------
https://chatgpt.com/codex/tasks/task_e_68d6c3cad894832a9cc048a693f490e3