### PR TITLE
Update pump.fun program ID handling

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -22,6 +22,13 @@ MAX_LAG=0
 USE_TA=false
 USE_TELEGRAM=false
 
+# Pump.fun
+ENABLE_PUMPFUN=false
+# Leave empty to use the mainnet default (pumpSn4aUAGb6nbeQC6GNxF4fA7nAMV9szbmWzxubQb)
+PUMPFUN_PROGRAM_ID=
+# Advanced: override the bonding curve account size if needed
+# PUMPFUN_BONDING_CURVE_ACCOUNT_SIZE=512
+
 # Buy
 QUOTE_MINT=WSOL
 QUOTE_AMOUNT=0.0004

--- a/helpers/pumpfun/index.ts
+++ b/helpers/pumpfun/index.ts
@@ -13,25 +13,21 @@ export const PUMPFUN_BONDING_CURVE_ACCOUNT_SIZE = Number.isFinite(parsedAccountS
   ? parsedAccountSize
   : DEFAULT_ACCOUNT_SIZE;
 
-const DEFAULT_PUMPFUN_PROGRAM_ID = new PublicKey(
-  'pumpHm9GYEucU5usmTr4Wr9PXAbQGzrYAKXLfX8Lm6Yz',
-);
+const DEFAULT_PUMPFUN_PROGRAM_ID_STRING = 'pumpSn4aUAGb6nbeQC6GNxF4fA7nAMV9szbmWzxubQb';
 
 const resolvePumpfunProgramId = () => {
   const override = process.env.PUMPFUN_PROGRAM_ID?.trim();
-
-  if (!override) {
-    return DEFAULT_PUMPFUN_PROGRAM_ID;
-  }
-
+  const candidate = override || DEFAULT_PUMPFUN_PROGRAM_ID_STRING;
   try {
-    return new PublicKey(override);
+    return new PublicKey(candidate);
   } catch {
-    console.warn(
-      `Invalid PUMPFUN_PROGRAM_ID "${override}" provided. Falling back to default program id.`,
-    );
+    if (override) {
+      console.warn(
+        `Invalid PUMPFUN_PROGRAM_ID "${override}" provided. Falling back to default program id.`,
+      );
+    }
 
-    return DEFAULT_PUMPFUN_PROGRAM_ID;
+    return new PublicKey(DEFAULT_PUMPFUN_PROGRAM_ID_STRING);
   }
 };
 


### PR DESCRIPTION
## Summary
- update the default pump.fun program id to the current mainnet deployment and validate it inside the resolver
- document how to override the pump.fun configuration in the example .env file

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d6cafa7668832aa433eefb02d3ed3a