### PR TITLE
Fix logging for unsupported pool types and fetch typings

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -164,6 +164,7 @@ export class Bot {
   public async buy(pool: PoolSnapshot, lag: number = 0): Promise<void> {
     const cachedPool = await this.poolStorage.get(pool.baseMint.toBase58());
     const poolSnapshot = cachedPool ?? pool;
+    const poolType = poolSnapshot.type;
     const poolMint = poolSnapshot.baseMint.toBase58();
 
     logger.trace({ mint: poolMint }, `Processing new pool...`);
@@ -175,7 +176,7 @@ export class Bot {
     }
 
     if (!isRaydiumPool(poolSnapshot)) {
-      logger.warn({ mint: poolMint }, `Unsupported pool type for buy operation: ${poolSnapshot.type}`);
+      logger.warn({ mint: poolMint }, `Unsupported pool type for buy operation: ${poolType}`);
       return;
     }
 
@@ -330,8 +331,10 @@ export class Bot {
         return;
       }
 
+      const poolType = poolData.type;
+
       if (!isRaydiumPool(poolData)) {
-        logger.warn({ mint: rawAccount.mint.toString() }, `Unsupported pool type for sell operation: ${poolData.type}`);
+        logger.warn({ mint: rawAccount.mint.toString() }, `Unsupported pool type for sell operation: ${poolType}`);
         return;
       }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2020"],                                  /* Ensure BigInt and other modern features are available during compilation. */
+    "lib": ["es2020", "dom"],                           /* Ensure BigInt, fetch, and other modern features are available during compilation. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
## Summary
- cache the pool type before type guard narrowing in buy and sell flows
- use the cached type value in unsupported pool logging to avoid TypeScript never errors
- include DOM lib declarations so fetch usage in the mutable filter compiles cleanly

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d6d19b9aa0832a90f698476f7385da