### PR TITLE
Allow Raydium pool updates without status filter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -283,6 +283,9 @@ const runListener = async () => {
 
   listeners.on('pool', async (updatedAccountInfo: KeyedAccountInfo) => {
     const poolState = LIQUIDITY_STATE_LAYOUT_V4.decode(updatedAccountInfo.accountInfo.data);
+    if (poolState.status.toNumber && poolState.status.toNumber() !== 6) {
+      return;
+    }
     const poolOpenTime = parseInt(poolState.poolOpenTime.toString());
     const exists = await poolCache.get(poolState.baseMint.toString());
 

--- a/listeners/listeners.ts
+++ b/listeners/listeners.ts
@@ -1,5 +1,4 @@
 import { LIQUIDITY_STATE_LAYOUT_V4, MAINNET_PROGRAM_ID, MARKET_STATE_LAYOUT_V3, Token } from '@raydium-io/raydium-sdk';
-import bs58 from 'bs58';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { EventEmitter } from 'events';
@@ -82,12 +81,6 @@ export class Listeners extends EventEmitter {
           memcmp: {
             offset: LIQUIDITY_STATE_LAYOUT_V4.offsetOf('marketProgramId'),
             bytes: MAINNET_PROGRAM_ID.OPENBOOK_MARKET.toBase58(),
-          },
-        },
-        {
-          memcmp: {
-            offset: LIQUIDITY_STATE_LAYOUT_V4.offsetOf('status'),
-            bytes: bs58.encode([6, 0, 0, 0, 0, 0, 0, 0]),
           },
         },
       ],


### PR DESCRIPTION
## Summary
- stop filtering Raydium pool account updates by the on-chain status flag in the websocket subscription so we receive all pool changes
- guard pool handling logic to ignore pools whose status is not ready for trading before attempting to buy

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d6e190ba74832a9fdb09fd02ba15c1