### PR TITLE
Fix pre-swap volume threshold to use quote-side totals

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -19,6 +19,11 @@ COMPUTE_UNIT_PRICE=421197
 # if using warp or jito executor, fee below will be applied
 CUSTOM_FEE=0.0001
 MAX_LAG=0
+MAX_PRE_SWAP_VOLUME=0
+# Threshold for quote-side swap volume before entering a pool (raw units, e.g. lamports for SOL).
+# Optional: express the threshold directly in quote token units (e.g. 0.1 for WSOL/USDC).
+# When provided this overrides MAX_PRE_SWAP_VOLUME.
+MAX_PRE_SWAP_VOLUME_IN_QUOTE=
 USE_TA=false
 USE_TELEGRAM=false
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You should see the following output:
   - Minimum value is 0.0001 SOL, but we recommend using 0.006 SOL or above
   - On top of this fee, minimal solana network fee will be applied
 - `MAX_LAG` - Ignore tokens that PoolOpenTime is longer than now + `MAX_LAG` seconds
+- `MAX_PRE_SWAP_VOLUME` - Allow pools where the combined quote-side swap volume (`swapQuoteInAmount` + `swapQuoteOutAmount`, in raw token units) is below this threshold; `0` keeps the previous behaviour of requiring zero swaps. Leave unset to rely on the quote-denominated option below.
+- `MAX_PRE_SWAP_VOLUME_IN_QUOTE` - Alternative, human-readable threshold expressed in quote token units (e.g. `0.1` for SOL or USDC). When set, this value overrides `MAX_PRE_SWAP_VOLUME`.
 - `USE_TA` - Use technical analysis for entries and exits (VERY HARD ON RPC's)
   - Set to `false` to disable technical analysis indicators; the MACD/RSI environment variables are not required in that case.
 - `USE_TELEGRAM` - Use telegram bot for notifications

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -33,6 +33,8 @@ export const CACHE_NEW_MARKETS = retrieveEnvVariable('CACHE_NEW_MARKETS', logger
 export const TRANSACTION_EXECUTOR = retrieveEnvVariable('TRANSACTION_EXECUTOR', logger);
 export const CUSTOM_FEE = retrieveEnvVariable('CUSTOM_FEE', logger);
 export const MAX_LAG = Number(retrieveEnvVariable('MAX_LAG', logger));
+export const MAX_PRE_SWAP_VOLUME_RAW = process.env.MAX_PRE_SWAP_VOLUME;
+export const MAX_PRE_SWAP_VOLUME_IN_QUOTE = process.env.MAX_PRE_SWAP_VOLUME_IN_QUOTE;
 export const USE_TELEGRAM = retrieveEnvVariable('USE_TELEGRAM', logger) === 'true';
 export const USE_TA = retrieveEnvVariable('USE_TA', logger) === 'true';
 export const ENABLE_PUMPFUN = (process.env.ENABLE_PUMPFUN ?? 'false') === 'true';

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import BN from 'bn.js';
 import { MarketCache, PoolCache, createRaydiumPoolSnapshot } from './cache';
 import { Listeners } from './listeners';
 import { Connection, KeyedAccountInfo, Keypair } from '@solana/web3.js';
@@ -49,6 +50,8 @@ import {
   TRAILING_STOP_LOSS,
   SKIP_SELLING_IF_LOST_MORE_THAN,
   MAX_LAG,
+  MAX_PRE_SWAP_VOLUME_IN_QUOTE,
+  MAX_PRE_SWAP_VOLUME_RAW,
   CHECK_HOLDERS,
   CHECK_ABNORMAL_DISTRIBUTION,
   CHECK_TOKEN_DISTRIBUTION,
@@ -78,7 +81,73 @@ const connection = new Connection(RPC_ENDPOINT, {
   commitment: COMMITMENT_LEVEL,
 });
 
-function printDetails(wallet: Keypair, quoteToken: Token, bot: Bot) {
+type ResolvedMaxPreSwapVolume = {
+  raw: BN;
+  display: string;
+};
+
+function resolveMaxPreSwapVolume(quoteToken: Token): ResolvedMaxPreSwapVolume {
+  const quoteThreshold = MAX_PRE_SWAP_VOLUME_IN_QUOTE?.trim();
+  const rawThreshold = MAX_PRE_SWAP_VOLUME_RAW?.trim();
+
+  if (quoteThreshold && rawThreshold) {
+    logger.warn(
+      'Both MAX_PRE_SWAP_VOLUME_IN_QUOTE and MAX_PRE_SWAP_VOLUME are set; using the quote-denominated value.',
+    );
+  }
+
+  if (quoteThreshold) {
+    const amount = new TokenAmount(quoteToken, quoteThreshold, false);
+
+    return {
+      raw: amount.raw,
+      display: `${quoteThreshold} ${quoteToken.symbol} (${amount.raw.toString()} raw units)`,
+    };
+  }
+
+  if (rawThreshold) {
+    if (rawThreshold.startsWith('-')) {
+      logger.warn('MAX_PRE_SWAP_VOLUME cannot be negative; defaulting to zero');
+    } else if (/^\d+$/.test(rawThreshold)) {
+      const rawValue = new BN(rawThreshold);
+      const approx = new TokenAmount(quoteToken, rawValue, true);
+
+      return {
+        raw: rawValue,
+        display: `${rawValue.toString()} raw units (~${approx.toFixed()} ${quoteToken.symbol})`,
+      };
+    } else {
+      try {
+        const amount = new TokenAmount(quoteToken, rawThreshold, false);
+        logger.warn(
+          `MAX_PRE_SWAP_VOLUME should be an integer raw amount. Interpreting "${rawThreshold}" as ${quoteToken.symbol}.`,
+        );
+
+        return {
+          raw: amount.raw,
+          display: `${rawThreshold} ${quoteToken.symbol} (${amount.raw.toString()} raw units)`,
+        };
+      } catch (error) {
+        logger.error({ err: error, rawThreshold }, 'Invalid MAX_PRE_SWAP_VOLUME value; defaulting to zero');
+      }
+    }
+  }
+
+  const zero = new BN(0);
+  const approx = new TokenAmount(quoteToken, zero, true);
+
+  return {
+    raw: zero,
+    display: `${zero.toString()} raw units (~${approx.toFixed()} ${quoteToken.symbol})`,
+  };
+}
+
+function printDetails(
+  wallet: Keypair,
+  quoteToken: Token,
+  bot: Bot,
+  maxPreSwapVolume: ResolvedMaxPreSwapVolume,
+) {
   logger.info(`  
                                         ..   :-===++++-     
                                 .-==+++++++- =+++++++++-    
@@ -116,6 +185,7 @@ function printDetails(wallet: Keypair, quoteToken: Token, bot: Bot) {
   logger.info(`Cache new markets: ${CACHE_NEW_MARKETS}`);
   logger.info(`Log level: ${LOG_LEVEL}`);
   logger.info(`Max lag: ${MAX_LAG}`);
+  logger.info(`Max pre swap volume: ${maxPreSwapVolume.display}`);
   logger.info(`Pump.fun listener enabled: ${botConfig.enablePumpfun}`);
   logger.info(`Telegram notifications: ${botConfig.useTelegram}`);
 
@@ -276,6 +346,9 @@ const runListener = async () => {
     enablePumpfun: ENABLE_PUMPFUN,
   });
 
+  const maxPreSwapVolume = resolveMaxPreSwapVolume(quoteToken);
+  const maxPreSwapVolumeRaw = maxPreSwapVolume.raw;
+
   listeners.on('market', (updatedAccountInfo: KeyedAccountInfo) => {
     const marketState = MARKET_STATE_LAYOUT_V3.decode(updatedAccountInfo.accountInfo.data);
     marketCache.save(updatedAccountInfo.accountId.toString(), marketState);
@@ -294,11 +367,13 @@ const runListener = async () => {
     poolCache.save(snapshot);
 
     const poolOpenTime = parseInt(poolState.poolOpenTime.toString());
-    const hasSwaps =
-      !poolState.swapBaseInAmount.eqn(0) ||
-      !poolState.swapQuoteInAmount.eqn(0) ||
-      !poolState.swapQuoteOutAmount.eqn(0) ||
-      !poolState.swapBaseOutAmount.eqn(0);
+    const totalSwapVolume = poolState.swapBaseInAmount
+      .add(poolState.swapBaseOutAmount)
+      .add(poolState.swapQuoteInAmount)
+      .add(poolState.swapQuoteOutAmount);
+
+    const hasSwaps = !totalSwapVolume.eqn(0);
+    const quoteSwapVolume = poolState.swapQuoteInAmount.add(poolState.swapQuoteOutAmount);
 
     if (!hasSwaps && poolOpenTime !== 0 && poolOpenTime < runTimestamp) {
       logger.trace({ mint: poolMint }, 'Skipping pool created before bot started');
@@ -306,8 +381,33 @@ const runListener = async () => {
     }
 
     if (hasSwaps) {
-      logger.trace({ mint: poolMint }, 'Skipping pool because swaps already occurred');
-      return;
+      if (maxPreSwapVolumeRaw.isZero()) {
+        logger.trace({ mint: poolMint }, 'Skipping pool because swaps already occurred');
+        return;
+      }
+
+      if (quoteSwapVolume.gt(maxPreSwapVolumeRaw)) {
+        logger.trace(
+          {
+            mint: poolMint,
+            totalSwapVolume: totalSwapVolume.toString(),
+            quoteSwapVolume: quoteSwapVolume.toString(),
+            maxPreSwapVolume: maxPreSwapVolumeRaw.toString(),
+          },
+          'Skipping pool because swaps already occurred',
+        );
+        return;
+      }
+
+      logger.trace(
+        {
+          mint: poolMint,
+          totalSwapVolume: totalSwapVolume.toString(),
+          quoteSwapVolume: quoteSwapVolume.toString(),
+          maxPreSwapVolume: maxPreSwapVolumeRaw.toString(),
+        },
+        'Pool has swaps within allowed threshold; continuing',
+      );
     }
 
     const currentTimestamp = Math.floor(new Date().getTime() / 1000);
@@ -338,7 +438,7 @@ const runListener = async () => {
     });
   }
 
-  printDetails(wallet, quoteToken, bot);
+  printDetails(wallet, quoteToken, bot, maxPreSwapVolume);
 };
 
 runListener();


### PR DESCRIPTION
## Summary
- compare pools' quote-side swap volume against the configured pre-swap threshold so quote-denominated settings are enforced
- document the quote-side volume check in the README and clarify the .env template comments

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d6e7adfb0c832a8286f79aa27d5081