### PR TITLE
Remove cached pools missing wallet accounts

### DIFF
--- a/cache/pool.cache.ts
+++ b/cache/pool.cache.ts
@@ -142,6 +142,10 @@ export class PoolCache {
     return this.keys.get(mint);
   }
 
+  public getUnsold(): PoolSnapshot[] {
+    return Array.from(this.keys.values()).filter((snapshot) => !snapshot.sold);
+  }
+
   public async markAsSold(mint: string): Promise<void> {
     const pool = this.keys.get(mint);
     if (pool) {
@@ -152,6 +156,12 @@ export class PoolCache {
       }
       await this.persist();
     }
+  }
+
+  public async remove(mint: string): Promise<void> {
+    this.keys.delete(mint);
+    this.persisted.delete(mint);
+    await this.persist();
   }
 
   private serialize(snapshot: PoolSnapshot, rawState?: Buffer): PersistedPoolSnapshot {


### PR DESCRIPTION
## Summary
- add a removal helper on the pool cache to drop positions with missing wallet accounts
- remove cached positions from storage when the wallet token account is absent during resume

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d9546e5198832a84116a8003f3dac5