### PR TITLE
Restore event-driven new pool gating with MAX_LAG filtering

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -132,8 +132,11 @@ export class Bot {
     }
   }
 
-  public async handlePumpfunPool(_payload: PumpfunPoolEventPayload): Promise<void> {
-    logger.trace('Received pump.fun pool update');
+  public async handlePumpfunPool(
+    _payload: PumpfunPoolEventPayload,
+    lagSeconds: number = 0,
+  ): Promise<void> {
+    logger.trace({ lag: lagSeconds }, 'Received pump.fun pool update');
   }
 
   async validate(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- gate Raydium pools by swaps, bot start time, and MAX_LAG before caching or buying so only fresh pools are processed
- track Raydium and pump.fun mints to avoid reprocessing skipped pools and reuse MAX_LAG constraints for pump.fun events
- extend the pump.fun handler to receive lag metadata for future integration

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d988025e78832ab170b1b91288f048