### PR TITLE
Restore Raydium new-pool gating and filter pumpfun by MAX_LAG

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -132,8 +132,11 @@ export class Bot {
     }
   }
 
-  public async handlePumpfunPool(_payload: PumpfunPoolEventPayload): Promise<void> {
-    logger.trace('Received pump.fun pool update');
+  public async handlePumpfunPool(
+    _payload: PumpfunPoolEventPayload,
+    lagSeconds: number = 0,
+  ): Promise<void> {
+    logger.trace({ lag: lagSeconds }, 'Received pump.fun pool update');
   }
 
   async validate(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- restore the original event-driven Raydium pool gating so pools are cached once, skipped if opened before startup, and filtered by MAX_LAG before buying
- apply startup-time and MAX_LAG filters to pump.fun bonding curves while tracking seen mints to avoid reprocessing

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d988025e78832ab170b1b91288f048