### PR TITLE
Restore MAX_LAG gating for Raydium and pumpfun listeners

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -132,8 +132,11 @@ export class Bot {
     }
   }
 
-  public async handlePumpfunPool(_payload: PumpfunPoolEventPayload): Promise<void> {
-    logger.trace('Received pump.fun pool update');
+  public async handlePumpfunPool(
+    _payload: PumpfunPoolEventPayload,
+    lagSeconds: number = 0,
+  ): Promise<void> {
+    logger.trace({ lag: lagSeconds }, 'Received pump.fun pool update');
   }
 
   async validate(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- normalize the MAX_LAG configuration before listener setup so Raydium pool handling skips stale launches while logging their lag context
- gate pump.fun bonding-curve events with the same MAX_LAG checks, skipping cached or completed curves before invoking the handler with the computed lag

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d988025e78832ab170b1b91288f048