### PR TITLE
Fix buy concurrency limit to use active sell monitor count

### DIFF
--- a/tradeSignals.ts
+++ b/tradeSignals.ts
@@ -27,7 +27,7 @@ export class TradeSignals {
         this.TA = new TechnicalAnalysis(config);
     }
 
-    private getActiveMonitorCount(): number {
+    public getActiveMonitorCount(): number {
         let count = 0;
 
         for (const mint of this.activeSellMonitors.keys()) {


### PR DESCRIPTION
## Summary
- base the token-processing cap on the number of running buy operations plus active sell monitors
- expose the sell monitor count from `TradeSignals` and enrich the skip log message for clarity

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d9bb182b80832a8f5b284c7d021fff