### PR TITLE
Stop monitoring tokens after extreme loss

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -364,9 +364,12 @@ export class Bot {
       for (let i = 0; i < this.config.maxSellRetries; i++) {
         try {
           if (i === 0) {
-            const shouldSell = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
+            const decision = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
 
-            if (!shouldSell) {
+            if (!decision.shouldSell) {
+              if (decision.reason === 'largeLoss') {
+                await this.poolStorage.markAsSold(rawAccount.mint.toString());
+              }
               return;
             }
           }


### PR DESCRIPTION
## Summary
- extend the sell signal flow to return detailed decisions
- stop monitoring tokens that have dropped beyond the configured loss threshold by marking them as sold

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68daf5ae18fc832a822cb94576fad3cf