### PR TITLE
Guard large loss sell decision handling

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -364,9 +364,12 @@ export class Bot {
       for (let i = 0; i < this.config.maxSellRetries; i++) {
         try {
           if (i === 0) {
-            const shouldSell = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
+            const decision = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
 
-            if (!shouldSell) {
+            if (!decision.shouldSell) {
+              if ('reason' in decision && decision.reason === 'largeLoss') {
+                await this.poolStorage.markAsSold(rawAccount.mint.toString());
+              }
               return;
             }
           }


### PR DESCRIPTION
## Summary
- guard access to sell decision reasons before marking pools as sold after a large loss

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68daf5ae18fc832a822cb94576fad3cf