### PR TITLE
Ensure large-loss monitoring exits reliably

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -364,9 +364,12 @@ export class Bot {
       for (let i = 0; i < this.config.maxSellRetries; i++) {
         try {
           if (i === 0) {
-            const shouldSell = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
+            const decision = await this.tradeSignals.waitForSellSignal(tokenAmountIn, poolKeys);
 
-            if (!shouldSell) {
+            if (!decision.shouldSell) {
+              if ('reason' in decision && decision.reason === 'largeLoss') {
+                await this.poolStorage.markAsSold(rawAccount.mint.toString());
+              }
               return;
             }
           }


### PR DESCRIPTION
## Summary
- ensure large-loss monitoring cut-off triggers when percentage loss exceeds the configured threshold
- keep sell monitoring stats accurate by returning immediately once the configured loss threshold is exceeded

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68daf5ae18fc832a822cb94576fad3cf