### PR TITLE
Configure env defaults for tighter risk controls

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -18,7 +18,7 @@ COMPUTE_UNIT_LIMIT=101337
 COMPUTE_UNIT_PRICE=421197
 # if using warp or jito executor, fee below will be applied
 CUSTOM_FEE=0.0001
-MAX_LAG=0
+MAX_LAG=15
 MAX_PRE_SWAP_VOLUME=0
 # Threshold for quote-side swap volume before entering a pool (raw units, e.g. lamports for SOL).
 # Optional: express the threshold directly in quote token units (e.g. 0.1 for WSOL/USDC).
@@ -51,10 +51,10 @@ MAX_SELL_RETRIES=10
 AUTO_SELL_DELAY=0
 PRICE_CHECK_INTERVAL=5000
 PRICE_CHECK_DURATION=0
-TAKE_PROFIT=120
-STOP_LOSS=0
+TAKE_PROFIT=80
+STOP_LOSS=30
 TRAILING_STOP_LOSS=false
-SKIP_SELLING_IF_LOST_MORE_THAN=0
+SKIP_SELLING_IF_LOST_MORE_THAN=90
 SELL_SLIPPAGE=20
 AUTO_SELL_WITHOUT_SELL_SIGNAL=true
 KEEP_5_PERCENT_FOR_MOONSHOTS=false

--- a/README.md
+++ b/README.md
@@ -92,7 +92,15 @@ You should see the following output:
   - This config is useful if you find yourself in a situation when rugpull happen, and you failed to sell. In this case there is a big loss of value, and sometimes it's more beneficial to keep the token, instead of selling it for almost nothing.
 - `SELL_SLIPPAGE` - Slippage %.
 - `AUTO_SELL_WITHOUT_SELL_SIGNAL` - Set `false` to keep holding tokens in case didn't find sell signal
-- `KEEP_5_PERCENT_FOR_MOONSHOTS` - Keep 5% of token. WARNING: consider token account rent expenses and TAKE_PROFIT and STOP_LOSS is skewed by small amount. 
+- `KEEP_5_PERCENT_FOR_MOONSHOTS` - Keep 5% of token. WARNING: consider token account rent expenses and TAKE_PROFIT and STOP_LOSS is skewed by small amount.
+
+##### Example risk management preset
+
+- `STOP_LOSS=30` – limits potential losses by exiting positions once they retrace more than 30% from the entry price.
+- `TAKE_PROFIT=80` – secures gains when the position appreciates by roughly 80%.
+- `PRICE_CHECK_INTERVAL=5000` – keeps the profit/loss evaluation cadence close to every 5 seconds.
+- `MAX_LAG=15` – ignores pools whose on-chain open time is more than 15 seconds old, ensuring only very recent tokens are considered.
+- `SKIP_SELLING_IF_LOST_MORE_THAN=90` – stops monitoring tokens that have collapsed by over 90% so new opportunities can be tracked without delays.
 
 #### Snipe list
 


### PR DESCRIPTION
## Summary
- lower the default stop-loss and take-profit thresholds to 30% and 80%
- enforce 15 second pool age and 90% loss skip settings in the sample environment file
- document a risk management preset in the README for the new defaults

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e3bc9b9934832abf0da2bfc713602b