### PR TITLE
Add Pump.fun take profit override to env template

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -31,6 +31,8 @@ USE_TELEGRAM=false
 ENABLE_PUMPFUN=false
 # Leave empty to use the mainnet default (pumpSn4aUAGb6nbeQC6GNxF4fA7nAMV9szbmWzxubQb)
 PUMPFUN_PROGRAM_ID=
+# Override the Pump.fun take profit percentage (falls back to 35 when empty)
+PUMPFUN_TAKE_PROFIT=
 # Advanced: override the bonding curve account size if needed
 # PUMPFUN_BONDING_CURVE_ACCOUNT_SIZE=512
 


### PR DESCRIPTION
## Summary
- add the optional `PUMPFUN_TAKE_PROFIT` variable to the environment template
- document that leaving the value empty falls back to the default 35% take profit

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e3dc624af0832abd1f12f188a6d2eb