### PR TITLE
docs: document compute budget fee example

### DIFF
--- a/docs/compute-cost-example.md
+++ b/docs/compute-cost-example.md
@@ -1,0 +1,26 @@
+# Compute Cost Example
+
+This document explains how to convert the configured compute budget parameters into an approximate SOL cost for a single transaction when using the default executor.
+
+## Given parameters
+- `COMPUTE_UNIT_LIMIT = 101337`
+- `COMPUTE_UNIT_PRICE = 421197` micro-lamports per compute unit
+
+## Conversion steps
+1. Convert the price from micro-lamports to lamports:
+   
+   ```
+   421197 micro-lamports = 421197 / 1_000_000 ≈ 0.421197 lamports per compute unit
+   ```
+2. Multiply by the compute unit limit to get the maximum lamports charged for compute budget priority fees:
+   
+   ```
+   0.421197 lamports * 101337 units ≈ 42,682.840389 lamports
+   ```
+3. Convert lamports to SOL (1 SOL = 1_000_000_000 lamports):
+   
+   ```
+   42,682.840389 lamports ≈ 0.000042682840389 SOL
+   ```
+
+Therefore, if a transaction consumes the full configured compute limit, the priority fee component would cost roughly **0.00004268 SOL** in addition to the baseline network fee. Actual spend can be lower if fewer compute units are used.


### PR DESCRIPTION
## Summary
- add a short guide that converts configured compute budget values into a SOL-denominated cost estimate

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e528d2bac4832a8806cb8bce527003