### PR TITLE
Prevent Raydium pool cache from retaining skipped pools

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -163,7 +163,7 @@ export class Bot {
     return await this.whitelistCache.isInList(this.connection, poolKeys);
   }
 
-  public async buy(pool: PoolSnapshot, lag: number = 0): Promise<void> {
+  public async buy(pool: PoolSnapshot, lag: number = 0, rawState?: Buffer): Promise<void> {
     const cachedPool = await this.poolStorage.get(pool.baseMint.toBase58());
     const poolSnapshot = cachedPool ?? pool;
     const poolType = poolSnapshot.type;
@@ -239,6 +239,10 @@ export class Bot {
           logger.trace({ mint: poolMint }, `Skipping buy because buy signal not received`);
           return;
         }
+      }
+
+      if (!cachedPool) {
+        await this.poolStorage.save(poolSnapshot, rawState);
       }
 
       const startTime = Date.now();

--- a/index.ts
+++ b/index.ts
@@ -666,7 +666,6 @@ const runListener = async () => {
     }
 
     const snapshot = createRaydiumPoolSnapshot(updatedAccountInfo.accountId.toBase58(), poolState);
-    await poolCache.save(snapshot, updatedAccountInfo.accountInfo.data);
 
     seenRaydiumMints.add(poolMint);
     logger.trace(
@@ -674,7 +673,7 @@ const runListener = async () => {
       'Raydium lag within threshold',
     );
 
-    await bot.buy(snapshot, evaluation.lagSeconds);
+    await bot.buy(snapshot, evaluation.lagSeconds, updatedAccountInfo.accountInfo.data);
   });
 
   listeners.on('wallet', async (updatedAccountInfo: KeyedAccountInfo) => {


### PR DESCRIPTION
## Summary
- stop persisting Raydium pool snapshots inside the listener before buy decisions
- persist pool details inside the buy flow only when the bot actually proceeds with a trade, passing along the raw pool state

## Testing
- npm run tsc

------
https://chatgpt.com/codex/tasks/task_e_68e7c4de1574832aae8e2da661dd8c4f