### PR TITLE
Fix os module import for ts-node compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js';
-import os from 'node:os';
+import os from 'os';
 import { MarketCache, PoolCache, createRaydiumPoolSnapshot } from './cache';
 import { Listeners } from './listeners';
 import { Connection, KeyedAccountInfo, Keypair } from '@solana/web3.js';


### PR DESCRIPTION
## Summary
- replace the `node:os` import with `os` to avoid TypeScript resolution errors when starting the bot

## Testing
- npm run start *(fails: PRIVATE_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d801f544832a8db860662dfa285c