### PR TITLE
Prune sold pool snapshots to reduce memory usage

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -326,6 +326,11 @@ export class Bot {
       logger.trace({ mint: rawAccount.mint.toString() }, `Processing new token...`);
 
       if (!poolData) {
+        if (this.poolStorage.wasSold(rawAccount.mint.toString())) {
+          logger.trace({ mint: rawAccount.mint.toString() }, `Skipping sell because token was already sold`);
+          return;
+        }
+
         logger.trace({ mint: rawAccount.mint.toString() }, `Token pool data is not found, can't sell`);
         return;
       }


### PR DESCRIPTION
## Summary
- prune sold pool snapshots from the cache, rewrite persisted storage, and remember only a bounded history of sold mints to keep memory usage under control
- update the sell flow to recognise mints that were already sold and avoid redundant processing

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e7f71de770832a80cce90af69ebbc3